### PR TITLE
Install local Babel and use local scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ O **GT Edition** oferece uma reinterpretação fiel do modo carreira clássico:
    ```bash
    cd launcher && npm install
    ```
+   Isso baixa o React, ReactDOM, React Router e Babel para a pasta `node_modules`, permitindo executar o app sem depender de CDN.
 2. Em outro terminal, instale os requisitos do backend e inicie a API:
    ```bash
    python3 -m venv venv

--- a/launcher/index.html
+++ b/launcher/index.html
@@ -15,10 +15,10 @@
   <img id="logo" src="../assets/logo.png" alt="Logo">
   <div id="root"></div>
   <audio id="bgm" src="../music/menu_theme.mp3" loop autoplay></audio>
-  <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-  <script src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.development.js"></script>
-  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script src="./node_modules/react/umd/react.development.js"></script>
+  <script src="./node_modules/react-dom/umd/react-dom.development.js"></script>
+  <script src="./node_modules/react-router-dom/dist/umd/react-router-dom.development.js"></script>
+  <script src="./node_modules/@babel/standalone/babel.min.js"></script>
   <script type="text/babel" src="./main.jsx"></script>
 </body>
 </html>

--- a/launcher/package.json
+++ b/launcher/package.json
@@ -9,6 +9,7 @@
     "electron": "^25.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.4.0"
+    "react-router-dom": "^6.4.0",
+    "@babel/standalone": "^7.22.20"
   }
 }


### PR DESCRIPTION
## Summary
- install `@babel/standalone` as a dependency
- load React and Babel from `node_modules` instead of from CDN
- clarify in README that dependencies are installed locally

## Testing
- `npm install --ignore-scripts` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68895a4fa4a8832ebb748523d73dab3d